### PR TITLE
Renaming namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ gem install etcdv3
 require 'etcdv3'
 
 # Insecure connection
-conn = Etcd.new(url: 'http://127.0.0.1:2379')
+conn = Etcdv3.new(url: 'http://127.0.0.1:2379')
 
 # Secure connection using default certificates
-conn = Etcd.new(url: 'https://hostname:port')
+conn = Etcdv3.new(url: 'https://hostname:port')
 
 # Secure connection with Auth
-conn = Etcd.new(url: 'https://hostname:port', user: "gary", password: "secret")
+conn = Etcdv3.new(url: 'https://hostname:port', user: "gary", password: "secret")
 
 # Secure connection specifying own certificates
 # Coming soon...

--- a/etcdv3.gemspec
+++ b/etcdv3.gemspec
@@ -4,7 +4,7 @@ require "etcdv3/version"
 
 Gem::Specification.new do |s|
   s.name = "etcdv3"
-  s.version = Etcd::VERSION
+  s.version = Etcdv3::VERSION
   s.homepage = "https://github.com/davissp14/etcdv3-ruby"
   s.summary = "A Etcd client library for Version 3"
   s.description = "Etcd v3 Ruby Client"
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_development_dependency("grpc", "1.2.0")
+  s.add_dependency("grpc", "1.2.0")
   s.add_development_dependency("rspec", "3.5.4")
 end

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -10,7 +10,7 @@ require 'etcdv3/maintenance'
 require 'etcdv3/lease'
 require 'etcdv3/request'
 
-class Etcd
+class Etcdv3
 
   attr_reader :credentials, :options
 

--- a/lib/etcdv3/auth.rb
+++ b/lib/etcdv3/auth.rb
@@ -1,5 +1,5 @@
 
-class Etcd
+class Etcdv3
   class Auth
 
     PERMISSIONS = {
@@ -79,7 +79,7 @@ class Etcd
 
     def grant_permission_to_role(name, permission, key, range_end)
       permission = Authpb::Permission.new(
-        permType: Etcd::Auth::PERMISSIONS[permission], key: key, range_end: range_end
+        permType: Etcdv3::Auth::PERMISSIONS[permission], key: key, range_end: range_end
       )
       @stub.role_grant_permission(
         Etcdserverpb::AuthRoleGrantPermissionRequest.new(

--- a/lib/etcdv3/kv.rb
+++ b/lib/etcdv3/kv.rb
@@ -1,5 +1,5 @@
 
-class Etcd
+class Etcdv3
   class KV
 
     SORT_TARGET = {

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -1,5 +1,5 @@
 
-class Etcd
+class Etcdv3
   class Lease
     def initialize(hostname, credentials, metadata={})
       @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials)

--- a/lib/etcdv3/maintenance.rb
+++ b/lib/etcdv3/maintenance.rb
@@ -1,6 +1,6 @@
 require 'ostruct'
 
-class Etcd
+class Etcdv3
   class Maintenance
     # Sadly these are the only alarm types supported by the api right now.
     ALARM_TYPES = {

--- a/lib/etcdv3/request.rb
+++ b/lib/etcdv3/request.rb
@@ -1,4 +1,4 @@
-class Etcd
+class Etcdv3
   class Request
 
     attr_reader :metacache
@@ -22,19 +22,19 @@ class Etcd
     end
 
     def auth
-      @auth ||= Etcd::Auth.new(@hostname, @credentials, @metadata)
+      @auth ||= Etcdv3::Auth.new(@hostname, @credentials, @metadata)
     end
 
     def kv
-      @kv ||= Etcd::KV.new(@hostname, @credentials, @metadata)
+      @kv ||= Etcdv3::KV.new(@hostname, @credentials, @metadata)
     end
 
     def maintenance
-      @maintenance ||= Etcd::Maintenance.new(@hostname, @credentials, @metadata)
+      @maintenance ||= Etcdv3::Maintenance.new(@hostname, @credentials, @metadata)
     end
 
     def lease
-      @lease ||= Etcd::Lease.new(@hostname, @credentials, @metadata)
+      @lease ||= Etcdv3::Lease.new(@hostname, @credentials, @metadata)
     end
 
   end

--- a/lib/etcdv3/version.rb
+++ b/lib/etcdv3/version.rb
@@ -1,3 +1,3 @@
-class Etcd
-  VERSION = '0.2.0'.freeze
+class Etcdv3
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/etcdv3/auth_spec.rb
+++ b/spec/etcdv3/auth_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Etcd::Auth do
+describe Etcdv3::Auth do
 
-  let(:stub) { local_stub(Etcd::Auth) }
+  let(:stub) { local_stub(Etcdv3::Auth) }
 
   describe '#add_user' do
     after { stub.delete_user('boom') }

--- a/spec/etcdv3/kv_spec.rb
+++ b/spec/etcdv3/kv_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Etcd::KV do
-  let(:stub) { local_stub(Etcd::KV) }
-  let(:lease_stub) { local_stub(Etcd::Lease) }
+describe Etcdv3::KV do
+  let(:stub) { local_stub(Etcdv3::KV) }
+  let(:lease_stub) { local_stub(Etcdv3::Lease) }
 
   describe '#put' do
     context 'without lease' do

--- a/spec/etcdv3/lease_spec.rb
+++ b/spec/etcdv3/lease_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Etcd::Lease do
+describe Etcdv3::Lease do
 
-  let(:stub) { local_stub(Etcd::Lease) }
+  let(:stub) { local_stub(Etcdv3::Lease) }
 
   describe '#grant_lease' do
     subject { stub.grant_lease(10) }

--- a/spec/etcdv3/maintenance_spec.rb
+++ b/spec/etcdv3/maintenance_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Etcd::Maintenance do
+describe Etcdv3::Maintenance do
 
-  let(:stub) { local_stub(Etcd::Maintenance) }
+  let(:stub) { local_stub(Etcdv3::Maintenance) }
 
   describe "#member_status" do
     subject { stub.member_status }

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Etcd do
+describe Etcdv3 do
   context 'Insecure connection without Auth' do
 
     let(:conn) { local_connection }

--- a/spec/helpers/connections.rb
+++ b/spec/helpers/connections.rb
@@ -2,7 +2,7 @@ module Helpers
   module Connections
 
     def local_connection
-      Etcd.new(url: "http://#{local_url}")
+      Etcdv3.new(url: "http://#{local_url}")
     end
 
     def local_stub(interface)


### PR DESCRIPTION
Renaming Etcd namespace to Etcdv3 for consistency reasons and due to naming conflicts in existing project. 

Fixing gemspec dependency issue.