### PR TITLE
First take on watch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ conn.lease_ttl(1234566789)
 conn.revoke_lease(1234566789)
 ```
 
+**Watch**
+```
+# Watch for changes on a specified key and return
+events = conn.watch('names')
+
+# Watch for changes on a specified key range and return
+events = conn.watch('boom', range_end: 'booooooom')
+
+# Watches for changes continuously until killed.
+event_count = 0
+conn.watch('boom') do |events|
+  puts events
+  event_count = event_count + 1
+  break if event_count >= 10
+end
+```
+
 **Alarms**
 ```
 # List all active Alarms

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -9,6 +9,7 @@ require 'etcdv3/kv'
 require 'etcdv3/maintenance'
 require 'etcdv3/lease'
 require 'etcdv3/request'
+require 'etcdv3/watch'
 
 class Etcdv3
 
@@ -63,6 +64,11 @@ class Etcdv3
   # Cluster leader id
   def leader_id
     request.handle(:maintenance, 'member_status').leader
+  end
+
+  # Watches for changes on a specified key range.
+  def watch(key, range_end: '', &block)
+    request.handle(:watch, 'watch', [key, range_end, block])
   end
 
   # List active alarms

--- a/lib/etcdv3/maintenance.rb
+++ b/lib/etcdv3/maintenance.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 class Etcdv3
   class Maintenance
     # Sadly these are the only alarm types supported by the api right now.

--- a/lib/etcdv3/request.rb
+++ b/lib/etcdv3/request.rb
@@ -37,5 +37,9 @@ class Etcdv3
       @lease ||= Etcdv3::Lease.new(@hostname, @credentials, @metadata)
     end
 
+    def watch
+      @watch ||= Etcdv3::Watch.new(@hostname, @credentials, @metadata)
+    end
+
   end
 end

--- a/lib/etcdv3/watch.rb
+++ b/lib/etcdv3/watch.rb
@@ -1,0 +1,26 @@
+class Etcdv3
+  class Watch
+
+    def initialize(hostname, credentials, metadata = {})
+      @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials)
+      @metadata = metadata
+    end
+
+    def watch(key, range_end, block)
+      create_req = Etcdserverpb::WatchCreateRequest.new(key: key, range_end: range_end)
+      watch_req = Etcdserverpb::WatchRequest.new(create_request: create_req)
+      events = nil
+      @stub.watch([watch_req]).each do |resp|
+        next if resp.events.empty?
+        if block
+          block.call(resp.events)
+        else
+          events = resp.events
+          break
+        end
+      end
+      events
+    end
+
+  end
+end


### PR DESCRIPTION
Opens up a watch request on a single stream.  

This offers two methods for listening for events:

1. Simply open up a watcher stream and return when event is triggered.
```
# This will simply block until it receives an event and return
events = conn.watch('mykey')  
```
2. When a block is provided, it will keep the stream open, which gives a bit more control on when to close it.
```
# Pass it a block to continuously stream events.
event_count = 0
conn.watch('mykey') do |events|
  puts events
  event_count = event_count + 1
  break if event_count >= 10
end 
```