### PR TITLE
Regenerate token automatically if expired

### DIFF
--- a/lib/etcdv3/request.rb
+++ b/lib/etcdv3/request.rb
@@ -1,35 +1,53 @@
+require 'base64'
 class Etcdv3
   class Request
 
-    attr_reader :metacache
+    HANDLERS = {
+      auth: Etcdv3::Auth,
+      kv: Etcdv3::KV,
+      maintenance: Etcdv3::Maintenance,
+      lease: Etcdv3::Lease,
+      watch: Etcdv3::Watch
+    }
 
-    def initialize(hostname, credentials, metadata, metacache='')
-      @handlers ||= handler_map(hostname, credentials, metadata)
-      @metacache = metacache
+    attr_reader :user, :password, :token
+
+    def initialize(hostname, credentials)
+      @user, @password, @token = nil, nil, nil
+      @hostname = hostname
+      @credentials = credentials
+      @handlers = handler_map
     end
 
-    def handle(stub, method, method_args=[])
+    def handle(stub, method, method_args=[], retries: 1)
       @handlers.fetch(stub).send(method, *method_args)
+    rescue GRPC::Unauthenticated => exception
+      # Regenerate token in the event it expires.
+      if exception.details == 'etcdserver: invalid auth token'
+        if retries > 0
+          authenticate(@user, @password)
+          return handle(stub, method, method_args, retries: retries - 1)
+        end
+      end
+      raise exception
+    end
+
+    def authenticate(user, password)
+      # Attempt to generate token using user and password.
+      @token = handle(:auth, 'generate_token', [user, password])
+      @user = user
+      @password = password
+      @handlers = handler_map(token: @token)
     end
 
     private
 
-    def handler_map(hostname, credentials, metadata)
+    def handler_map(metadata={})
       Hash[
-        handler_constants.map do |key, klass|
-          [key, klass.new(hostname, credentials, metadata)]
+        HANDLERS.map do |key, klass|
+          [key, klass.new(@hostname, @credentials, metadata)]
         end
       ]
-    end
-
-    def handler_constants
-      {
-        auth: Etcdv3::Auth,
-        kv: Etcdv3::KV,
-        maintenance: Etcdv3::Maintenance,
-        lease: Etcdv3::Lease,
-        watch: Etcdv3::Watch
-      }
     end
   end
 end

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -201,7 +201,7 @@ describe Etcdv3 do
       end
       after { conn.user_delete('root') }
       subject { conn.auth_disable }
-      it { is_expected.to be_an_instance_of(Etcdserverpb::AuthDisableResponse) }
+      it { is_expected.to eq(true) }
     end
 
     describe '#auth_enable' do
@@ -215,7 +215,7 @@ describe Etcdv3 do
         conn.user_delete('root')
       end
       subject { conn.auth_enable }
-      it { is_expected.to be_an_instance_of(Etcdserverpb::AuthEnableResponse) }
+      it { is_expected.to eq(true) }
     end
 
     describe "#authenticate" do
@@ -241,33 +241,6 @@ describe Etcdv3 do
         it 'raises error' do
           expect { conn.authenticate('root', 'root') }.to raise_error(GRPC::InvalidArgument)
         end
-      end
-    end
-
-    describe '#metacache' do
-      context 'uses cached request object' do
-        let!(:object_id) { conn.send(:request).object_id }
-        before { conn.user_add('root', 'test') }
-        after { conn.user_delete('root') }
-        subject { conn.send(:request).object_id }
-        it { is_expected.to eq(object_id) }
-      end
-      context 'resets cache on auth' do
-        let!(:object_id) { conn.send(:request).object_id }
-        before do
-          conn.user_add('root', 'test')
-          conn.user_grant_role('root', 'root')
-          conn.auth_enable
-          conn.authenticate('root', 'test')
-          conn.user_add('boom', 'password')
-        end
-        after do
-          conn.auth_disable
-          conn.user_delete('root')
-          conn.user_delete('boom')
-        end
-        subject { conn.send(:request).object_id }
-        it { is_expected.to_not eq(object_id) }
       end
     end
   end


### PR DESCRIPTION
Auth tokens will expire after being idle for 5 minutes.  Normally, once a token expires and you try to execute a command it will fail with `GRPC::Unauthenticated`.  This PR will attempt to re-authenticate in the event this exception is raised and retry the operation automatically.  