### PR TITLE
Bumping grpc version to 1.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem "grpc"
-gem 'faraday', '0.11.0'
+gemspec
 
-gem 'rspec', :group => :test
 gem 'codecov', :require => false, :group => :test

--- a/etcdv3.gemspec
+++ b/etcdv3.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency("grpc", "1.2.0")
-  s.add_development_dependency("rspec", "3.5.4")
+  s.add_dependency("grpc", "1.2.5")
+  s.add_dependency("faraday", "0.11.0")
+  s.add_development_dependency("rspec")
 end


### PR DESCRIPTION
Details: 
https://github.com/grpc/grpc/releases/tag/v1.2.5