### PR TITLE
Add in initial implementation of Session *DO NOT MERGE*

### DIFF
--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -9,9 +9,9 @@ require 'etcdv3/kv/transaction'
 require 'etcdv3/kv'
 require 'etcdv3/maintenance'
 require 'etcdv3/lease'
+require 'etcdv3/lease_keep_alive'
 require 'etcdv3/watch'
 require 'etcdv3/enumerator_queue'
-require 'etcdv3/session'
 
 require 'etcdv3/request'
 

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -10,6 +10,8 @@ require 'etcdv3/kv'
 require 'etcdv3/maintenance'
 require 'etcdv3/lease'
 require 'etcdv3/watch'
+require 'etcdv3/enumerator_queue'
+require 'etcdv3/session'
 
 require 'etcdv3/request'
 

--- a/lib/etcdv3/enumerator_queue.rb
+++ b/lib/etcdv3/enumerator_queue.rb
@@ -1,0 +1,23 @@
+
+class Etcdv3
+  class EnumeratorQueue
+    extend Forwardable
+    def_delegators :@q, :push
+
+    def initialize(sentinel)
+      @q = Queue.new
+      @sentinel = sentinel
+    end
+
+    def each_item
+      return enum_for(:each_item) unless block_given?
+      loop do
+        r = @q.pop
+        break if r.equal?(@sentinel)
+        fail r if r.is_a? Exception
+        yield r
+      end
+    end
+  end
+end
+

--- a/lib/etcdv3/enumerator_queue.rb
+++ b/lib/etcdv3/enumerator_queue.rb
@@ -1,12 +1,18 @@
 
 class Etcdv3
   class EnumeratorQueue
+    SENTINEL = Object.new
+
     extend Forwardable
     def_delegators :@q, :push
 
-    def initialize(sentinel)
+    def initialize(sentinel: SENTINEL)
       @q = Queue.new
       @sentinel = sentinel
+    end
+
+    def cancel
+      @q.push(@sentinel)
     end
 
     def each_item

--- a/lib/etcdv3/enumerator_queue.rb
+++ b/lib/etcdv3/enumerator_queue.rb
@@ -15,6 +15,10 @@ class Etcdv3
       @q.push(@sentinel)
     end
 
+    def error(error)
+      @q.push(error)
+    end
+
     def each_item
       return enum_for(:each_item) unless block_given?
       loop do

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -1,5 +1,43 @@
-
 class Etcdv3
+  class KeepAlive
+    def initialize(stub,
+                   lease_id,
+                   refresh_padding: 10,
+                   listener: nil)
+      @lease_id = id
+      @refresh_padding = refresh_padding
+      @q = EnumeratorQueue.new
+      @responses = @stub.lease_keep_alive(@q)
+
+      # Session listener that can receive messages
+      # like:
+      #   1. on_open - called when the session opens
+      #   2. on_error - called when the session errors for some reason
+      #   3. on_close - called when the session is closed by user
+      @listener = listener
+      @lock = Monitor.new
+
+      @response_thread = Thread.new do
+        begin
+          @responses.each do |_|
+            # Do nothing
+          end
+        rescue => e
+          on_error(e)
+        end
+
+        on_close
+      end
+
+      @keep_alive_thread = Thread.new do
+      end
+    end
+
+    def cancel
+      @q.cancel
+    end
+  end
+
   class Lease
     def initialize(hostname, credentials, metadata={})
       @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials)
@@ -21,12 +59,27 @@ class Etcdv3
       @stub.lease_time_to_live(request, metadata: @metadata)
     end
 
-    def lease_keep_alive(ids)
-      requests = ids.map do |id|
-        Etcdserverpb::LeaseKeepAliveRequest.new ID: id
-      end
-
-      @stub.lease_keep_alive(requests)
+    # This will keep the lease alive for
+    # as long as the stream is kept open
+    #
+    # Returns a LeaseKeepAlive
+    # Call close to close the stream and stop
+    # refreshing the lease
+    #
+    # id - the id of the lease to keep alive
+    # keep_alive_padding - how much padding to give to the refresh calls
+    #   if the TTL of the lease is 60 seconds and the refresh_padding
+    #   is 10 seconds, then a lease keep alive request will be
+    #   sent to the server every 50 seconds. refresh_padding must
+    #   be at least 1 second and at most 1 second less than the TTL.
+    # listener - object that receives lifetime hooks
+    def lease_keep_alive(id,
+                         keep_alive_padding: LeaseKeepAlive::DEFAULT_KEEP_ALIVE_PADDING,
+                         listener: nil)
+      LeaseKeepAlive.new(@stub,
+                         id,
+                         keep_alive_padding: keep_alive_padding,
+                         listener: listener)
     end
 
 

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -1,43 +1,5 @@
+
 class Etcdv3
-  class KeepAlive
-    def initialize(stub,
-                   lease_id,
-                   refresh_padding: 10,
-                   listener: nil)
-      @lease_id = id
-      @refresh_padding = refresh_padding
-      @q = EnumeratorQueue.new
-      @responses = @stub.lease_keep_alive(@q)
-
-      # Session listener that can receive messages
-      # like:
-      #   1. on_open - called when the session opens
-      #   2. on_error - called when the session errors for some reason
-      #   3. on_close - called when the session is closed by user
-      @listener = listener
-      @lock = Monitor.new
-
-      @response_thread = Thread.new do
-        begin
-          @responses.each do |_|
-            # Do nothing
-          end
-        rescue => e
-          on_error(e)
-        end
-
-        on_close
-      end
-
-      @keep_alive_thread = Thread.new do
-      end
-    end
-
-    def cancel
-      @q.cancel
-    end
-  end
-
   class Lease
     def initialize(hostname, credentials, metadata={})
       @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials)

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -21,6 +21,13 @@ class Etcdv3
       @stub.lease_time_to_live(request, metadata: @metadata)
     end
 
+    def lease_keep_alive(ids)
+      requests = ids.map do |id|
+        Etcdserverpb::LeaseKeepAliveRequest.new ID: id
+      end
+
+      @stub.lease_keep_alive(requests)
+    end
 
 
   end

--- a/lib/etcdv3/session.rb
+++ b/lib/etcdv3/session.rb
@@ -1,0 +1,126 @@
+
+class Etcdv3
+  # A session is used to keep a lease alive for the duration
+  # of a connection with an etcd3 server.
+  #
+  # This is useful for implementing functionality, such
+  # as distributed locks, where it may be necessary to
+  # maintain a lock as long as the connection is alive
+  # and well.
+  #
+  # Session provides a way to hook into events using a
+  # listener. This will allow our applications to respond
+  # in case we let a lease expire accidentally or there
+  # is a connection issue and we need to close the session.
+  class Session
+    def initialize(conn,
+                   keep_alive_interval: 10,
+                   lease_ttl: 15,
+                   listener: nil)
+      # The etcd3 connection to associate the session with
+      @conn = conn
+
+      # Monitor used to synchronize access to the session
+      # we use a Monitor instead of Mutex for reentrancy
+      @lock = Monitor.new
+
+      # How often we send a keep alive request
+      @keep_alive_interval = keep_alive_interval
+
+      # Session listener that can receive messages
+      # like:
+      #   1. on_open - called when the session opens
+      #   2. on_error - called when the session errors for some reason
+      #   3. on_close - called when the session is closed by user
+      @listener = listener
+
+      # The Time To Live for the lease
+      @lease_ttl = lease_ttl
+
+      # Create the lease that we will keep open for the
+      # duration of the session
+      @lease = @conn.lease_grant(@lease_ttl)
+
+      # Use this queue object to push keep
+      # alive requests to the server
+      @q = EnumeratorQueue.new(self)
+
+      # Get the enumerable that comes back
+      # with all of the responses from the
+      # etcd3 server
+      @responses = @conn.lease_keep_alive(@q)
+
+      # We are in the OPEN state until
+      # until we close the session or
+      # receive an error
+      @state = :OPEN
+
+      # Call on_open of the listener if passed in
+      on_open
+      @listener.on_open(self) if @listener
+
+      # This thread is responsible for monitoring
+      # the responses from the server in case
+      # something goes wrong
+      @response_thread = Thread.new do
+        begin
+          @responses.each do |_|
+            # Don't need to do anything with
+            # the responses for now
+          end
+        rescue => e
+          on_error(e)
+        end
+      end
+
+      # This thread is responsible for keeping the
+      # lease alive
+      @keep_alive_thread = Thread.new do
+        sleep @refresh_interval
+        @q.push @lease.ID
+      end
+    end
+
+    def close
+      @lock.synchronize
+    end
+
+    private
+
+    def on_open
+      @lock.synchronize do
+        @listener.on_open(self) if @listener
+      end
+    end
+
+    def on_error(error)
+      @lock.synchronize do
+        @listener.on_error(self, error) if @listener
+
+        @q.push(error)
+
+        @keep_alive_thread.join
+        @response_thread.join
+
+        @state = :ERROR
+      end
+    end
+
+    def on_close
+      @lock.synchronize do
+        # Can only close a currently open session
+        if state == :OPEN
+          @listener.on_close(self) if @listener
+
+          # Let the keep alive connection know we are done
+          @q.push(self)
+
+          @keep_alive_thread.join
+          @response_thread.join
+
+          @state = :CLOSED
+        end
+      end
+    end
+  end
+end

--- a/lib/etcdv3/session.rb
+++ b/lib/etcdv3/session.rb
@@ -93,6 +93,12 @@ class Etcdv3
       end
     end
 
+    def lease_id
+      @loack.synchronize do
+        @lease.ID
+      end
+    end
+
     private
 
     def on_open

--- a/lib/etcdv3/session.rb
+++ b/lib/etcdv3/session.rb
@@ -113,9 +113,6 @@ class Etcdv3
 
         @q.push(error)
 
-        @keep_alive_thread.join
-        @response_thread.join
-
         @state = :ERROR
       end
     end
@@ -128,9 +125,6 @@ class Etcdv3
 
           # Let the keep alive connection know we are done
           @q.push(self)
-
-          @keep_alive_thread.join
-          @response_thread.join
 
           @state = :CLOSED
         end

--- a/lib/etcdv3/session.rb
+++ b/lib/etcdv3/session.rb
@@ -82,7 +82,15 @@ class Etcdv3
     end
 
     def close
-      @lock.synchronize
+      @lock.synchronize do
+        on_close
+      end
+    end
+
+    def lease
+      @lock.synchronize do
+        @lease
+      end
     end
 
     private


### PR DESCRIPTION
** THIS PR IS NOT READY TO BE MERGED **

I wanted to get this PR in in order to start a discussion on a rather useful construct `Session`, based loosely on this Go code:

https://github.com/coreos/etcd/blob/master/clientv3/concurrency/session.go

The idea of a Session is to provide a lease that lasts the entire duration of the client lifetime until the gRPC channel is closed (or in the case of Ruby until the Session is closed).

This is an untested implementation, and is meant as a starting point for further discussion on how it should be implemented, what features we want, and what guarantees we should make.