### PR TITLE
Fix failing auth disable test

### DIFF
--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -238,6 +238,13 @@ describe Etcdv3 do
       end
 
       context 'auth disabled' do
+        before do
+          conn.user_add('root', 'root')
+          conn.auth_disable
+        end
+        after do
+          conn.user_delete('root')
+        end
         it 'raises error' do
           expect { conn.authenticate('root', 'root') }.to raise_error(GRPC::FailedPrecondition)
         end


### PR DESCRIPTION
The test fails unless the user has already been added. This change
ensures that the user exists and that auth is disabled in a before and
after block.

If the user doesn't exist the actual error thrown is:

```
GRPC::InvalidArgument: 3:etcdserver: authentication failed, invalid user ID or password>
```