### PR TITLE
remove unused faraday gem

### DIFF
--- a/etcdv3.gemspec
+++ b/etcdv3.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.add_dependency("grpc", "1.2.5")
-  s.add_dependency("faraday", "0.11.0")
   s.add_development_dependency("rspec")
 end


### PR DESCRIPTION
It doesn't seem that it is used for anything, and it's locked to a pretty old, pretty specific version - minimally, can it be upgraded?