### PR TITLE
Removing Ruby 2.0 from versions tested by Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-  - 2.4.0
+  - 2.4.1
   - 2.2
-  - 2.0
 
 env:
   global:


### PR DESCRIPTION
Seems there was a regression with the Ruby 2.0 build within Travis.  Given it's pretty old, going to remove it from the list.    