### PR TITLE
Allow tranaction puts to accept a lease ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ conn.transaction do |txn|
   ]
   
   txn.failure = [
-    txn.put('txn1', 'failed')
+    txn.put('txn1', 'failed', lease: lease_id)
   ]
 end
 ```

--- a/lib/etcdv3/kv/transaction.rb
+++ b/lib/etcdv3/kv/transaction.rb
@@ -36,9 +36,9 @@ class Etcdv3::KV
 
     # Request Operations
 
-    # txn.put('my', 'key')
-    def put(key, value)
-      put_request(key, value)
+    # txn.put('my', 'key', lease_id: 1)
+    def put(key, value, lease=nil)
+      put_request(key, value, lease)
     end
 
     # txn.get('key')

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -255,7 +255,7 @@ describe Etcdv3 do
       context 'success' do
         before { conn.put('txn', 'value') }
         after { conn.del('txn') }
-        subject do
+        subject! do
           conn.transaction do |txn|
             txn.compare = [ txn.value('txn', :equal, 'value') ]
             txn.success = [ txn.put('txn-test', 'success') ]
@@ -271,10 +271,27 @@ describe Etcdv3 do
         end
       end
 
+      context "success, with a lease" do
+        let!(:lease_id) { conn.lease_grant(2)['ID'] }
+        before { conn.put('txn', 'value') }
+        subject! do
+          conn.transaction do |txn|
+            txn.compare = [ txn.value('txn', :equal, 'value') ]
+            txn.success = [ txn.put('txn-test', 'success', lease_id) ]
+            txn.failure = [ txn.put('txn-test', 'failed', lease_id) ]
+          end
+        end
+
+        it 'sets correct key, with a lease' do
+          expect(conn.get('txn-test').kvs.first.value).to eq('success')
+          expect(conn.get('txn-test').kvs.first.lease).to eq(lease_id)
+        end
+      end
+
       context 'failure' do
         before { conn.put('txn', 'value') }
         after { conn.del('txn') }
-        subject do
+        subject! do
           conn.transaction do |txn|
             txn.compare = [
               txn.create_revision('txn', :greater, 500),
@@ -292,6 +309,5 @@ describe Etcdv3 do
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
This lets you pass in a lease id in transaction.put.

Additionally, there were several tests which failed when they were the
only one getting run because `subject` is evaluated lazily. This changes
it to subject! which always gets evaluated.