### PR TITLE
Add Timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port', user: 'root', password: 'm
 # Secure connection specifying custom certificates
 # Coming soon...
 
+# Per-request timeouts
+conn = Etcdv3.new(endpoints: 'https://hostname:port', command_timeout: 5) # seconds
+
 ```
 **High Availability**
 
@@ -169,6 +172,27 @@ conn.alarm_list
 # Deactivate ALL active Alarms
 conn.alarm_deactivate
 ```
+
+## Timeouts
+
+The default timeout for all requests is 120 seconds. A timeout can be set on the connection:
+
+```ruby
+conn = Etcdv3.new(endpoints: 'https://hostname:port', command_timeout: 5) # seconds
+```
+
+Or a timeout can be set on an individual request.
+
+```ruby
+conn = Etcdv3.new(endpoints: 'https://hostname:port', command_timeout: 5)
+conn.get("foo", timeout: 2) # Timeout of 2 seconds
+```
+
+This timeout applies to and can be set when:
+ - Adding, Fetching and Deleting keys
+ - User, Role, and Authentication Management
+ - Leases
+ - Transactions
 
 ## Contributing
 

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -16,11 +16,13 @@ class Etcdv3
   extend Forwardable
   def_delegators :@conn, :user, :password, :token, :endpoints, :authenticate
 
-  attr_reader :conn, :options
+  attr_reader :conn, :credentials, :options
+  DEFAULT_TIMEOUT = 120
 
   def initialize(options = {})
     @options = options
-    @conn = ConnectionWrapper.new(sanitized_endpoints)
+    @timeout = options[:command_timeout] || DEFAULT_TIMEOUT
+    @conn = ConnectionWrapper.new(@timeout, *sanitized_endpoints)
     warn "WARNING: `url` is deprecated. Please use `endpoints` instead." if @options.key?(:url)
     authenticate(@options[:user], @options[:password]) if @options.key?(:user)
   end

--- a/lib/etcdv3/auth.rb
+++ b/lib/etcdv3/auth.rb
@@ -8,37 +8,38 @@ class Etcdv3
       :readwrite => Authpb::Permission::Type::READWRITE
     }
 
-    def initialize(hostname, credentials, metadata = {})
+    def initialize(hostname, credentials, timeout, metadata = {})
       @stub = Etcdserverpb::Auth::Stub.new(hostname, credentials)
+      @timeout = timeout
       @metadata = metadata
     end
 
-    def auth_enable
+    def auth_enable(timeout: nil)
       request = Etcdserverpb::AuthEnableRequest.new
-      @stub.auth_enable(request)
+      @stub.auth_enable(request, deadline: deadline(timeout))
     end
 
-    def auth_disable
+    def auth_disable(timeout: nil)
       request = Etcdserverpb::AuthDisableRequest.new
-      @stub.auth_disable(request, metadata: @metadata)
+      @stub.auth_disable(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def role_add(name)
+    def role_add(name, timeout: nil)
       request = Etcdserverpb::AuthRoleAddRequest.new(name: name)
-      @stub.role_add(request, metadata: @metadata)
+      @stub.role_add(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def role_get(name)
+    def role_get(name, timeout: nil)
       request = Etcdserverpb::AuthRoleGetRequest.new(role: name)
-      @stub.role_get(request, metadata: @metadata)
+      @stub.role_get(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def role_delete(name)
+    def role_delete(name, timeout: nil)
       request = Etcdserverpb::AuthRoleDeleteRequest.new(role: name)
-      @stub.role_delete(request, metadata: @metadata)
+      @stub.role_delete(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def role_grant_permission(name, permission, key, range_end)
+    def role_grant_permission(name, permission, key, range_end, timeout: nil)
       permission = Authpb::Permission.new(
         permType: Etcdv3::Auth::PERMISSIONS[permission], key: key, range_end: range_end
       )
@@ -47,74 +48,81 @@ class Etcdv3
           name: name,
           perm: permission
         ),
-        metadata: @metadata
+        metadata: @metadata,
+        deadline: deadline(timeout)
       )
     end
 
-    def role_revoke_permission(name, permission, key, range_end)
+    def role_revoke_permission(name, permission, key, range_end, timeout: nil)
       @stub.role_revoke_permission(
         Etcdserverpb::AuthRoleRevokePermissionRequest.new(
           role: name,
           key: key,
           range_end: range_end
         ),
-        metadata: @metadata
+        metadata: @metadata,
+        deadline: deadline(timeout)
       )
     end
 
-    def role_list
+    def role_list(timeout: nil)
       request = Etcdserverpb::AuthRoleListRequest.new
-      @stub.role_list(request, metadata: @metadata)
+      @stub.role_list(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_list
+    def user_list(timeout: nil)
       request = Etcdserverpb::AuthUserListRequest.new
-      @stub.user_list(request, metadata: @metadata)
+      @stub.user_list(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_add(user, password)
+    def user_add(user, password, timeout: nil)
       request = Etcdserverpb::AuthUserAddRequest.new(
         name: user,
         password: password
       )
-      @stub.user_add(request, metadata: @metadata)
+      @stub.user_add(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_delete(user)
+    def user_delete(user, timeout: nil)
       request = Etcdserverpb::AuthUserDeleteRequest.new(name: user)
-      @stub.user_delete(request, metadata: @metadata)
+      @stub.user_delete(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_get(user)
+    def user_get(user, timeout: nil)
       request = Etcdserverpb::AuthUserGetRequest.new(name: user)
-      @stub.user_get(request, metadata: @metadata)
+      @stub.user_get(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_change_password(user, new_password)
+    def user_change_password(user, new_password, timeout: nil)
       request = Etcdserverpb::AuthUserChangePasswordRequest.new(
         name: user,
         password: new_password
       )
-      @stub.user_change_password(request, metadata: @metadata)
+      @stub.user_change_password(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_grant_role(user, role)
+    def user_grant_role(user, role, timeout: nil)
       request = Etcdserverpb::AuthUserGrantRoleRequest.new(user: user, role: role)
-      @stub.user_grant_role(request, metadata: @metadata)
+      @stub.user_grant_role(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def user_revoke_role(user, role)
+    def user_revoke_role(user, role, timeout: nil)
       request = Etcdserverpb::AuthUserRevokeRoleRequest.new(name: user, role: role)
-      @stub.user_revoke_role(request, metadata: @metadata)
+      @stub.user_revoke_role(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def generate_token(user, password)
+    def generate_token(user, password, timeout: nil)
       request = Etcdserverpb::AuthenticateRequest.new(
         name: user,
         password: password
       )
-      @stub.authenticate(request).token
+      @stub.authenticate(request, deadline: deadline(timeout)).token
     end
 
+    private
+
+    def deadline(timeout)
+      Time.now.to_f + (timeout || @timeout)
+    end
   end
 end

--- a/lib/etcdv3/connection.rb
+++ b/lib/etcdv3/connection.rb
@@ -11,10 +11,11 @@ class Etcdv3
 
     attr_reader :endpoint, :hostname, :handlers, :credentials
 
-    def initialize(url, metadata={})
+    def initialize(url, timeout, metadata={})
       @endpoint = URI(url)
       @hostname = "#{@endpoint.hostname}:#{@endpoint.port}"
       @credentials = resolve_credentials
+      @timeout = timeout
       @handlers = handler_map(metadata)
     end
 
@@ -31,7 +32,7 @@ class Etcdv3
     def handler_map(metadata={})
       Hash[
         HANDLERS.map do |key, klass|
-          [key, klass.new("#{@hostname}", @credentials, metadata)]
+          [key, klass.new("#{@hostname}", @credentials, @timeout, metadata)]
         end
       ]
     end

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -1,11 +1,12 @@
 class Etcdv3
   class ConnectionWrapper
 
-    attr_accessor :connection, :endpoints, :user, :password, :token
+    attr_accessor :connection, :endpoints, :user, :password, :token, :timeout
 
-    def initialize(endpoints)
+    def initialize(timeout, *endpoints)
       @user, @password, @token = nil, nil, nil
-      @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint) }
+      @timeout = timeout
+      @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout) }
       @connection = @endpoints.first
     end
 

--- a/lib/etcdv3/kv.rb
+++ b/lib/etcdv3/kv.rb
@@ -3,24 +3,26 @@ class Etcdv3
   class KV
     include Etcdv3::KV::Requests
 
-    def initialize(hostname, credentials, metadata={})
+    def initialize(hostname, credentials, timeout, metadata={})
       @stub = Etcdserverpb::KV::Stub.new(hostname, credentials)
+      @timeout = timeout
       @metadata = metadata
     end
 
     def get(key, opts={})
-      @stub.range(get_request(key, opts), metadata: @metadata)
+      timeout = opts.delete(:timeout)
+      @stub.range(get_request(key, opts), metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def del(key, range_end="")
-      @stub.delete_range(del_request(key, range_end), metadata: @metadata)
+    def del(key, range_end="", timeout: nil)
+      @stub.delete_range(del_request(key, range_end), metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def put(key, value, lease=nil)
-      @stub.put(put_request(key, value, lease), metadata: @metadata)
+    def put(key, value, lease=nil, timeout: nil)
+      @stub.put(put_request(key, value, lease), metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def transaction(block)
+    def transaction(block, timeout: nil)
       txn = Etcdv3::KV::Transaction.new
       block.call(txn)
       request = Etcdserverpb::TxnRequest.new(
@@ -28,10 +30,14 @@ class Etcdv3
         success: generate_request_ops(txn.success),
         failure: generate_request_ops(txn.failure)
       )
-      @stub.txn(request)
+      @stub.txn(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
     private
+
+    def deadline(timeout)
+      Time.now.to_f + (timeout || @timeout)
+    end
 
     def generate_request_ops(requests)
       requests.map do |request|

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -1,27 +1,30 @@
-
 class Etcdv3
   class Lease
-    def initialize(hostname, credentials, metadata={})
+    def initialize(hostname, credentials, timeout, metadata={})
       @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials)
+      @timeout = timeout
       @metadata = metadata
     end
 
-    def lease_grant(ttl)
+    def lease_grant(ttl, timeout: nil)
       request = Etcdserverpb::LeaseGrantRequest.new(TTL: ttl)
-      @stub.lease_grant(request, metadata: @metadata)
+      @stub.lease_grant(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def lease_revoke(id)
+    def lease_revoke(id, timeout: nil)
       request = Etcdserverpb::LeaseRevokeRequest.new(ID: id)
-      @stub.lease_revoke(request, metadata: @metadata)
+      @stub.lease_revoke(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
-    def lease_ttl(id)
+    def lease_ttl(id, timeout: nil)
       request = Etcdserverpb::LeaseTimeToLiveRequest.new(ID: id, keys: true)
-      @stub.lease_time_to_live(request, metadata: @metadata)
+      @stub.lease_time_to_live(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
+    private
 
-
+    def deadline(timeout)
+      Time.now.to_f + (timeout || @timeout)
+    end
   end
 end

--- a/lib/etcdv3/maintenance.rb
+++ b/lib/etcdv3/maintenance.rb
@@ -12,7 +12,7 @@ class Etcdv3
       deactivate: 2
     }
 
-    def initialize(hostname, credentials, metadata = {})
+    def initialize(hostname, credentials, _timeout, metadata = {})
       @stub = Etcdserverpb::Maintenance::Stub.new(hostname, credentials)
       @metadata = metadata
     end

--- a/lib/etcdv3/watch.rb
+++ b/lib/etcdv3/watch.rb
@@ -1,7 +1,7 @@
 class Etcdv3
   class Watch
 
-    def initialize(hostname, credentials, metadata = {})
+    def initialize(hostname, credentials, _timeout, metadata = {})
       @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials)
       @metadata = metadata
     end

--- a/spec/etcdv3/auth_spec.rb
+++ b/spec/etcdv3/auth_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Etcdv3::Auth do
 
-  let(:stub) { local_stub(Etcdv3::Auth) }
+  let(:stub) { local_stub(Etcdv3::Auth, 1) }
+
+  it_should_behave_like "a method with a GRPC timeout", described_class, :auth_disable, :auth_disable
 
   describe '#user_add' do
     after { stub.user_delete('boom') }
@@ -14,17 +16,21 @@ describe Etcdv3::Auth do
     before { stub.user_add('user_get', 'password') }
     after { stub.user_delete('user_get') }
     subject { stub.user_get('user_get') }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_get, :user_get, 'user_get'
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGetResponse) }
   end
 
   describe '#user_list' do
     subject { stub.user_list }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_list, :user_list
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserListResponse) }
   end
 
   describe '#user_delete' do
     before { stub.user_add('user_delete', 'test') }
     subject { stub.user_delete('user_delete') }
+    after { stub.user_delete('user_delete') rescue nil }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_delete, :user_delete, 'user_delete'
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserDeleteResponse) }
   end
 
@@ -32,6 +38,7 @@ describe Etcdv3::Auth do
     before { stub.user_add('grant_user', 'test') }
     after { stub.user_delete('grant_user') }
     subject { stub.user_grant_role('grant_user', 'root') }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_grant_role, :user_grant_role, 'grant_user', 'root'
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGrantRoleResponse) }
   end
 
@@ -42,15 +49,20 @@ describe Etcdv3::Auth do
     end
     after { stub.user_delete('revoke_user') }
     subject { stub.user_revoke_role('revoke_user', 'root') }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_revoke_role, :user_revoke_role, 'revoke_user', 'root'
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserRevokeRoleResponse) }
   end
 
   describe '#role_add' do
-    after { stub.role_delete('role_add') }
     subject { stub.role_add('role_add') }
     it 'adds a role' do
       expect(subject).to be_an_instance_of(Etcdserverpb::AuthRoleAddResponse)
       expect(stub.role_list.roles).to include('role_add')
+    end
+    describe "timeouts of role_add" do
+      after { stub.role_delete('role_add') rescue nil }
+      before { stub.role_delete('role_add') rescue nil }
+      it_should_behave_like "a method with a GRPC timeout", described_class, :role_add, :role_add, 'role_add'
     end
   end
 
@@ -59,19 +71,26 @@ describe Etcdv3::Auth do
     after { stub.role_delete('role_get') }
     subject { stub.role_get('role_get') }
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthRoleGetResponse) }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :role_get, :role_get, 'role_get'
   end
 
   describe '#role_delete' do
     before { stub.role_add('role_delete') }
     subject { stub.role_delete('role_delete') }
+
     it 'deletes role' do
       expect(subject).to be_an_instance_of(Etcdserverpb::AuthRoleDeleteResponse)
       expect(stub.role_list.roles).to_not include('role_delete')
+    end
+    describe "timeouts of role_delete" do
+      after { stub.role_delete 'role_delete' rescue nil }
+      it_should_behave_like "a method with a GRPC timeout", described_class, :role_delete, :role_delete, 'role_delete'
     end
   end
 
   describe '#role_list' do
     subject { stub.role_list }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :role_list, :role_list
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthRoleListResponse) }
   end
 
@@ -79,6 +98,7 @@ describe Etcdv3::Auth do
     before { stub.role_add('grant_perm') }
     after { stub.role_delete('grant_perm') }
     subject { stub.role_grant_permission('grant_perm', :write, 'c', 'cc') }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :role_grant_permission, :role_grant_permission, 'grant_perm', :write, 'c', 'cc'
     it 'sets permission' do
       expect(subject).to be_an_instance_of(Etcdserverpb::AuthRoleGrantPermissionResponse)
     end
@@ -91,6 +111,9 @@ describe Etcdv3::Auth do
     end
     after { stub.role_delete('myrole') }
     subject { stub.role_revoke_permission('myrole', :write, 'c', 'cc') }
+
+    it_should_behave_like "a method with a GRPC timeout", described_class, :role_revoke_permission, :role_revoke_permission, 'myrole', :write, 'c', 'cc'
+
     it 'revokes permission' do
       expect(subject).to be_an_instance_of(Etcdserverpb::AuthRoleRevokePermissionResponse)
       expect(stub.role_get('myrole').perm.size).to eq(0)
@@ -101,6 +124,7 @@ describe Etcdv3::Auth do
     before { stub.user_add('myuser', 'test') }
     after { stub.user_delete('myuser') }
     subject { stub.user_change_password('myuser', 'boom') }
+    it_should_behave_like "a method with a GRPC timeout", described_class, :user_change_password, :user_change_password, 'myuser', 'boom'
     it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserChangePasswordResponse) }
   end
 

--- a/spec/etcdv3/connection_spec.rb
+++ b/spec/etcdv3/connection_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Etcdv3::Connection do
 
   describe '#initialize - without metadata' do
-    subject { Etcdv3::Connection.new('http://localhost:2379') }
+    subject { Etcdv3::Connection.new('http://localhost:2379', 10) }
 
     it { is_expected.to have_attributes(endpoint: URI('http://localhost:2379')) }
     it { is_expected.to have_attributes(credentials: :this_channel_is_insecure) }
@@ -22,7 +22,7 @@ describe Etcdv3::Connection do
   end
 
   describe '#initialize - with metadata' do
-    subject { Etcdv3::Connection.new('http://localhost:2379', token: 'token123') }
+    subject { Etcdv3::Connection.new('http://localhost:2379', 10, token: 'token123') }
 
     [:kv, :maintenance, :lease, :watch, :auth].each do |handler|
       let(:handler_stub) { subject.handlers[handler].instance_variable_get(:@stub) }

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -5,7 +5,7 @@ describe Etcdv3::ConnectionWrapper do
   let(:endpoints) { ['http://localhost:2379', 'http://localhost:2389'] }
 
   describe '#initialize' do
-    subject { Etcdv3::ConnectionWrapper.new(endpoints) }
+    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
     it { is_expected.to have_attributes(user: nil, password: nil, token: nil) }
     it 'sets hostnames in correct order' do
       expect(subject.endpoints.map(&:hostname)).to eq(['localhost:2379', 'localhost:2389'])
@@ -16,7 +16,7 @@ describe Etcdv3::ConnectionWrapper do
   end
 
   describe "#rotate_connection_endpoint" do
-    subject { Etcdv3::ConnectionWrapper.new(endpoints) }
+    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
     before do
       subject.rotate_connection_endpoint
     end

--- a/spec/etcdv3/kv_spec.rb
+++ b/spec/etcdv3/kv_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe Etcdv3::KV do
-  let(:stub) { local_stub(Etcdv3::KV) }
-  let(:lease_stub) { local_stub(Etcdv3::Lease) }
+  let(:stub) { local_stub(Etcdv3::KV, 1) }
+  let(:lease_stub) { local_stub(Etcdv3::Lease, 1) }
+
+  it_should_behave_like "a method with a GRPC timeout", described_class, :get, :range, "key"
+  it_should_behave_like "a method with a GRPC timeout", described_class, :del, :delete_range, "key"
+  it_should_behave_like "a method with a GRPC timeout", described_class, :put, :put, "key", "val"
+
+  it "should timeout transactions" do
+    stub = local_stub(Etcdv3::KV, 0)
+    expect { stub.transaction(Proc.new { nil }) }.to raise_error(GRPC::DeadlineExceeded)
+  end
 
   describe '#put' do
     context 'without lease' do

--- a/spec/etcdv3/lease_spec.rb
+++ b/spec/etcdv3/lease_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe Etcdv3::Lease do
 
-  let(:stub) { local_stub(Etcdv3::Lease) }
+  let(:stub) { local_stub(Etcdv3::Lease, 5) }
 
+  it_should_behave_like "a method with a GRPC timeout", described_class, :lease_grant, :lease_grant, 10
   describe '#lease_grant' do
     subject { stub.lease_grant(10) }
     it 'grants lease' do
@@ -16,12 +17,22 @@ describe Etcdv3::Lease do
     let(:id) { stub.lease_grant(60)['ID'] }
     subject { stub.lease_revoke(id) }
     it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseRevokeResponse) }
+
+    it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
+      stub = local_stub(Etcdv3::Lease, 0)
+      expect { stub.lease_revoke(id) }.to raise_error(GRPC::DeadlineExceeded)
+    end
   end
 
   describe '#lease_ttl' do
-    let(:id) { stub.lease_grant(10)['ID'] }
-    subject { stub.lease_ttl(id) }
+    let(:stub) { local_stub(Etcdv3::Lease, 1) }
+    let(:lease_id) { stub.lease_grant(10)['ID'] }
+    subject { stub.lease_ttl(lease_id) }
     it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseTimeToLiveResponse) }
-  end
 
+    it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
+      stub = local_stub(Etcdv3::Lease, 0)
+      expect { stub.lease_ttl(lease_id) }.to raise_error(GRPC::DeadlineExceeded)
+    end
+  end
 end

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -30,6 +30,19 @@ describe Etcdv3 do
           expect{ auth_conn }.to_not raise_error
         end
       end
+      context 'with a timeout' do
+        it "sets the timeout in the kv handler" do
+          etcd = local_connection_with_timeout(1.5)
+          kv_handler = etcd.conn.connection.instance_variable_get("@handlers")[:kv]
+          expect(kv_handler.instance_variable_get "@timeout").to eq(1.5)
+        end
+
+        it "sets a default timeout" do
+          etcd = local_connection
+          kv_handler = etcd.conn.connection.instance_variable_get("@handlers")[:kv]
+          expect(kv_handler.instance_variable_get "@timeout").to eq(120)
+        end
+      end
     end
 
     describe '#version' do

--- a/spec/helpers/connections.rb
+++ b/spec/helpers/connections.rb
@@ -9,8 +9,12 @@ module Helpers
       Etcdv3.new(endpoints: endpoints)
     end
 
-    def local_stub(interface)
-      interface.new(local_url, :this_channel_is_insecure, {})
+    def local_connection_with_timeout(timeout)
+      Etcdv3.new(endpoints: "http://#{local_url}", command_timeout: timeout)
+    end
+
+    def local_stub(interface, timeout=nil)
+      interface.new(local_url, :this_channel_is_insecure, timeout, {})
     end
 
     def local_url

--- a/spec/helpers/shared_examples_for_timeout.rb
+++ b/spec/helpers/shared_examples_for_timeout.rb
@@ -1,0 +1,28 @@
+shared_examples_for "a method with a GRPC timeout" do |stub_class, method_name, expectation_target, *args|
+  context "#{stub_class} timeouts for #{method_name}" do
+    let(:handler) { local_stub(stub_class, 5) }
+    let(:client_stub) { handler.instance_variable_get "@stub"}
+    it 'uses the timeout value' do
+      start_time = Time.now
+      deadline_time = start_time.to_f + 5
+      allow(Time).to receive(:now).and_return(start_time)
+
+      expect(client_stub).to receive(expectation_target).with(anything, hash_including(deadline: deadline_time)).and_call_original
+
+      handler.public_send(method_name, *args)
+    end
+
+    it "can have a seperate timeout passed in" do
+      start_time = Time.now
+      deadline_time = start_time.to_f + 1
+      allow(Time).to receive(:now).and_return(start_time)
+      expect(client_stub).to receive(expectation_target).with(anything, hash_including(deadline: deadline_time)).and_call_original
+      handler.public_send(method_name, *args, timeout: 1)
+    end
+
+    it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
+      handler = local_stub(stub_class, 0)
+      expect {handler.public_send(method_name, *args)}.to raise_error(GRPC::DeadlineExceeded)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'simplecov'
 require 'codecov'
 require 'helpers/test_instance'
 require 'helpers/connections'
+require 'helpers/shared_examples_for_timeout'
 
 SimpleCov.start
 SimpleCov.formatter = SimpleCov::Formatter::Codecov


### PR DESCRIPTION
This adds support for GRPC timeouts to KV operations. If this looks
good, we'll add it to the other operations and add docs for it, but we
wanted to run it up the flagpole first.