### PR TITLE
Fix circular argument reference warning

### DIFF
--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -185,7 +185,7 @@ class Etcdv3
     @conn.handle(:watch, 'watch', [key, range_end, block])
   end
 
-  def transaction(timeout: timeout, &block)
+  def transaction(timeout: nil, &block)
     @conn.handle(:kv, 'transaction', [block, timeout: timeout])
   end
 


### PR DESCRIPTION
This fixes a warning message introduced in 7044c1e68c4f0bd0cc6d4aa36da173f0aea01ade. Just looks like mistake.

```
etcdv3-ruby/lib/etcdv3.rb:188: warning: circular argument reference - timeout
```

Thanks!