### PR TITLE
Update grpc version

### DIFF
--- a/etcdv3.gemspec
+++ b/etcdv3.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency("grpc", "1.6.0")
+  s.add_dependency("grpc", "~> 1.6")
   s.add_development_dependency("rspec")
 end


### PR DESCRIPTION
Updating the grpc gem. In addition, unpinning the patch version.

If unpinning the patch version doesn't work for you, I would at least like to update the gem to 1.6.7.