### PR TITLE
This adds keep_alive_once to send once keep alive request

### DIFF
--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -116,6 +116,11 @@ class Etcdv3
     @conn.handle(:lease, 'lease_ttl', [id, timeout: timeout])
   end
 
+  # Sends one lease keep-alive request
+  def lease_keep_alive_once(id, timeout: nil)
+    @conn.handle(:lease, 'lease_keep_alive_once', [id, timeout: timeout])
+  end
+
   # List all roles.
   def role_list(timeout: nil)
     @conn.handle(:auth, 'role_list', [timeout: timeout])

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -21,6 +21,13 @@ class Etcdv3
       @stub.lease_time_to_live(request, metadata: @metadata, deadline: deadline(timeout))
     end
 
+    def lease_keep_alive_once(id, timeout: nil)
+      request = Etcdserverpb::LeaseKeepAliveRequest.new(ID: id)
+      @stub.lease_keep_alive([request], metadata: @metadata, deadline: deadline(timeout)).each do |resp|
+        return resp
+      end
+    end
+
     private
 
     def deadline(timeout)

--- a/spec/etcdv3/lease_spec.rb
+++ b/spec/etcdv3/lease_spec.rb
@@ -24,6 +24,16 @@ describe Etcdv3::Lease do
     end
   end
 
+  describe '#lease_keep_alive_once' do
+    let(:id) { stub.lease_grant(60)['ID'] }
+    subject { stub.lease_keep_alive_once(id) }
+    it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseKeepAliveResponse) }
+    it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
+      stub = local_stub(Etcdv3::Lease, 0)
+      expect { stub.lease_keep_alive_once(id) }.to raise_error(GRPC::DeadlineExceeded)
+    end
+  end
+
   describe '#lease_ttl' do
     let(:stub) { local_stub(Etcdv3::Lease, 1) }
     let(:lease_id) { stub.lease_grant(10)['ID'] }

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -160,6 +160,20 @@ describe Etcdv3 do
       end
     end
 
+    describe '#lease_keep_alive_once' do
+      let!(:lease_id) { conn.lease_grant(2)['ID'] }
+      subject { conn.lease_keep_alive_once(lease_id) }
+      it { is_expected.to_not be_nil }
+      it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
+        expect do
+          conn.lease_keep_alive_once(lease_id, timeout: 0)
+        end.to raise_exception(GRPC::DeadlineExceeded)
+      end
+      it "accepts a timeout" do
+        expect{ conn.lease_keep_alive_once(lease_id, timeout: 10) }.to_not raise_exception
+      end
+    end
+
     describe '#user_add' do
       after { conn.user_delete('test') rescue nil }
       subject { conn.user_add('test', 'user') }


### PR DESCRIPTION
This adds a method to send one keep-alive request. The Go client has a similar method, and also a method that takes a channel to listen to continuous requests on, but we didn't see an obvious way to doing that here (and we didn't need it).

Co-authored with @jcalvert