### PR TITLE
This fixes failing tests that ensure an error is raised on timeout.

### DIFF
--- a/etcdv3.gemspec
+++ b/etcdv3.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency("grpc", "~> 1.6.0")
+  s.add_dependency("grpc", "~> 1.6")
   s.add_development_dependency("rspec", "~> 3.6.0")
 end

--- a/spec/etcdv3/kv_spec.rb
+++ b/spec/etcdv3/kv_spec.rb
@@ -9,7 +9,7 @@ describe Etcdv3::KV do
   it_should_behave_like "a method with a GRPC timeout", described_class, :put, :put, "key", "val"
 
   it "should timeout transactions" do
-    stub = local_stub(Etcdv3::KV, 0)
+    stub = local_stub(Etcdv3::KV, -1)
     expect { stub.transaction(Proc.new { nil }) }.to raise_error(GRPC::DeadlineExceeded)
   end
 

--- a/spec/etcdv3/lease_spec.rb
+++ b/spec/etcdv3/lease_spec.rb
@@ -19,7 +19,7 @@ describe Etcdv3::Lease do
     it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseRevokeResponse) }
 
     it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
-      stub = local_stub(Etcdv3::Lease, 0)
+      stub = local_stub(Etcdv3::Lease, -1)
       expect { stub.lease_revoke(id) }.to raise_error(GRPC::DeadlineExceeded)
     end
   end
@@ -29,7 +29,7 @@ describe Etcdv3::Lease do
     subject { stub.lease_keep_alive_once(id) }
     it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseKeepAliveResponse) }
     it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
-      stub = local_stub(Etcdv3::Lease, 0)
+      stub = local_stub(Etcdv3::Lease, -1)
       expect { stub.lease_keep_alive_once(id) }.to raise_error(GRPC::DeadlineExceeded)
     end
   end
@@ -41,7 +41,7 @@ describe Etcdv3::Lease do
     it { is_expected.to be_an_instance_of(Etcdserverpb::LeaseTimeToLiveResponse) }
 
     it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
-      stub = local_stub(Etcdv3::Lease, 0)
+      stub = local_stub(Etcdv3::Lease, -1)
       expect { stub.lease_ttl(lease_id) }.to raise_error(GRPC::DeadlineExceeded)
     end
   end

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -138,7 +138,7 @@ describe Etcdv3 do
       it { is_expected.to_not be_nil }
       it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
         expect do
-          conn.lease_revoke(lease_id, timeout: 0)
+          conn.lease_revoke(lease_id, timeout: -1)
         end.to raise_exception(GRPC::DeadlineExceeded)
       end
       it "accepts a timeout" do
@@ -152,7 +152,7 @@ describe Etcdv3 do
       it { is_expected.to_not be_nil }
       it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
         expect do
-          conn.lease_ttl(lease_id, timeout: 0)
+          conn.lease_ttl(lease_id, timeout: -1)
         end.to raise_exception(GRPC::DeadlineExceeded)
       end
       it "accepts a timeout" do
@@ -166,7 +166,7 @@ describe Etcdv3 do
       it { is_expected.to_not be_nil }
       it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
         expect do
-          conn.lease_keep_alive_once(lease_id, timeout: 0)
+          conn.lease_keep_alive_once(lease_id, timeout: -1)
         end.to raise_exception(GRPC::DeadlineExceeded)
       end
       it "accepts a timeout" do
@@ -354,7 +354,7 @@ describe Etcdv3 do
           end
           it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
             expect do
-              conn.transaction(timeout: 0) do |txn|
+              conn.transaction(timeout: -1) do |txn|
                 txn.compare = [ txn.value('txn', :equal, 'value') ]
                 txn.success = [ txn.put('txn-test', 'success') ]
                 txn.failure = [ txn.put('txn-test', 'failed') ]

--- a/spec/helpers/shared_examples_for_timeout.rb
+++ b/spec/helpers/shared_examples_for_timeout.rb
@@ -21,7 +21,7 @@ shared_examples_for "a method with a GRPC timeout" do |stub_class, method_name, 
     end
 
     it 'raises a GRPC:DeadlineExceeded if the request takes too long' do
-      handler = local_stub(stub_class, 0)
+      handler = local_stub(stub_class, -1)
       expect {handler.public_send(method_name, *args)}.to raise_error(GRPC::DeadlineExceeded)
     end
   end
@@ -31,7 +31,7 @@ shared_examples_for "Etcdv3 instance using a timeout" do |command, *args|
   it "raises a GRPC::DeadlineExceeded exception when it takes too long"  do
     expect do
       test_args = args.dup
-      test_args.push({timeout: 0})
+      test_args.push({timeout: -1})
       conn.public_send(command, *test_args)
     end.to raise_exception(GRPC::DeadlineExceeded)
   end


### PR DESCRIPTION
Having a timeout set to zero wasn't rasing an error if we have
previously connected to etcd in that test run.

We fixed it by passing in negative timeouts, and we un-pinned
the GRPC version.

co-authored with @jcalvert