### PR TITLE
Fix code coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift File.expand_path('./helpers', __FILE__)
 
-require 'etcdv3'
 require 'simplecov'
 require 'codecov'
+SimpleCov.start
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
+require 'etcdv3'
 require 'helpers/test_instance'
 require 'helpers/connections'
 require 'helpers/shared_examples_for_timeout'
-
-SimpleCov.start
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 RSpec.configure do |config|
   config.include(Helpers::Connections)


### PR DESCRIPTION
The code coverage is now broken. This shows only the coverage for the specs.

https://github.com/colszowka/simplecov
SimpleCov Getting Started:
> Note: If SimpleCov starts after your application code is already loaded (via require), it won't be able to track your files and their coverage! The SimpleCov.start must be issued before any of your application code is required!

I moved the lines above so that the 'lib' directory also got covered.
