### PR TITLE
Support secure connection with custom certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port')
 conn = Etcdv3.new(endpoints: 'https://hostname:port', user: 'root', password: 'mysecretpassword')
 
 # Secure connection specifying custom certificates
-# Coming soon...
-
+conn = Etcdv3.new(endpoints: 'https://hostname:port', custom_certificates: {
+  root_ca: 'path-to-root-ca.pem',
+  key: 'path-to-private-key.pem',
+  cert: 'path-to-cert.pem'
+})
 ```
 **High Availability**
 

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -24,7 +24,8 @@ class Etcdv3
   def initialize(options = {})
     @options = options
     @timeout = options[:command_timeout] || DEFAULT_TIMEOUT
-    @conn = ConnectionWrapper.new(@timeout, *sanitized_endpoints)
+    @custom_certificates = options[:custom_certificates]
+    @conn = ConnectionWrapper.new(endpoints: sanitized_endpoints, timeout: @timeout, custom_certificates: @custom_certificates)
     warn "WARNING: `url` is deprecated. Please use `endpoints` instead." if @options.key?(:url)
     authenticate(@options[:user], @options[:password]) if @options.key?(:user)
   end

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -3,10 +3,11 @@ class Etcdv3
 
     attr_accessor :connection, :endpoints, :user, :password, :token, :timeout
 
-    def initialize(timeout, *endpoints)
+    def initialize(endpoints:, timeout:, custom_certificates: nil)
       @user, @password, @token = nil, nil, nil
       @timeout = timeout
-      @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout) }
+      @custom_certificates = custom_certificates
+      @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout, {}, @custom_certificates) }
       @connection = @endpoints.first
     end
 

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -5,7 +5,7 @@ describe Etcdv3::ConnectionWrapper do
   let(:endpoints) { ['http://localhost:2379', 'http://localhost:2389'] }
 
   describe '#initialize' do
-    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
+    subject { Etcdv3::ConnectionWrapper.new(endpoints: endpoints, timeout: 10) }
     it { is_expected.to have_attributes(user: nil, password: nil, token: nil) }
     it 'sets hostnames in correct order' do
       expect(subject.endpoints.map(&:hostname)).to eq(['localhost:2379', 'localhost:2389'])
@@ -16,7 +16,7 @@ describe Etcdv3::ConnectionWrapper do
   end
 
   describe "#rotate_connection_endpoint" do
-    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
+    subject { Etcdv3::ConnectionWrapper.new(endpoints: endpoints, timeout: 10) }
     before do
       subject.rotate_connection_endpoint
     end


### PR DESCRIPTION
- Add `custom_certificates` in the initialization options of `Etcdv3`
- Pass down `custom_certificates` down to `Connection` to initialize Channel
- Noway to test the instance of `GRPC::Core::ChannlCertificates` since the certs variables are locked C layer.