### PR TITLE
Remove automatic retries in case of errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.bundle
 Gemfile.lock
 Guardfile
 *.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.bundle
 Gemfile.lock
 Guardfile
 *.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-Gemfile.lock
-Guardfile
-*.sh
 *.gem
-/tmp/
+*.sh
+*.swp
+/.bundle
 /.idea
 /coverage/*
 /doc/
-*.swp
+/tmp/
+Gemfile.lock
+Guardfile

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ In the event of a failure, the client will work to restore connectivity by cycli
 behaviour.
 
 However, sometimes this is not what you want. If you need more control over
-failures (and therefore having `timeout:` provide at least some guarantees),
-you can suppress this mechanism by using
+failures, you can suppress this mechanism by using
 
 ```ruby
 conn = Etcdv3.new(endpoints: 'https://hostname:port', allow_reconnect: false)
@@ -45,7 +44,11 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port', allow_reconnect: false)
 
 This will still rotate the endpoints, but it will raise an exception so you can
 handle the failure yourself. On next call new endpoint (since they were
-rotated) is tried.
+rotated) is tried. One thing you need to keep in mind if you are using etcd with
+authorization is that you need to take care of `GRPC::Unauthenticated` exceptions
+and manually re-authenticate when token expires. To reiterate, you are
+responsible for handling the errors, so some understanding of how this gem and
+etcd works is recommended.
 
 ## Adding, Fetching and Deleting Keys
 ```ruby

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port', user: 'root', password: 'm
 ```
 **High Availability**
 
-In the event of a failure, the gem will rotate through the specified
-endpoints so next one is tried on the next network call. The method call that
-trigger the error is not auto-retried, this responsibility lies with the calling
-application.
+In the event of a failure, the client will work to restore connectivity by cycling through the specified endpoints until a connection can be established.  With that being said, it is encouraged to specify multiple endpoints when available.
+
 
 ## Adding, Fetching and Deleting Keys
 ```ruby
@@ -108,9 +106,6 @@ Disabling auth will clear the auth token and all previously attached user inform
 ```
 conn.auth_disable
 ```
-
-When/if credentials expires, etcd3 call will raise `GRPC::Unauthenticated` and
-you will need to authenticate again.
 
 ## Leases
 ```ruby
@@ -215,9 +210,8 @@ Timeouts apply to and can be set when:
  - User, Role, and Authentication Management
  - Leases
  - Transactions
- - Watch
 
-_Note: Timeouts currently do not affect Maintenance related commands._
+_Note: Timeouts currently do not affect Watch or Maintenance related commands._
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,20 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port', user: 'root', password: 'm
 ```
 **High Availability**
 
-In the event of a failure, the client will work to restore connectivity by cycling through the specified endpoints until a connection can be established.  With that being said, it is encouraged to specify multiple endpoints when available.
+In the event of a failure, the client will work to restore connectivity by cycling through the specified endpoints until a connection can be established.  With that being said, it is encouraged to specify multiple endpoints when available. That's the default
+behaviour.
 
+However, sometimes this is not what you want. If you need more control over
+failures (and therefore having `timeout:` provide at least some guarantees),
+you can suppress this mechanism by using
+
+```ruby
+conn = Etcdv3.new(endpoints: 'https://hostname:port', allow_reconnect: false)
+```
+
+This will still rotate the endpoints, but it will raise an exception so you can
+handle the failure yourself. On next call new endpoint (since they were
+rotated) is tried.
 
 ## Adding, Fetching and Deleting Keys
 ```ruby

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ conn = Etcdv3.new(endpoints: 'https://hostname:port', user: 'root', password: 'm
 ```
 **High Availability**
 
-In the event of a failure, the client will work to restore connectivity by cycling through the specified endpoints until a connection can be established.  With that being said, it is encouraged to specify multiple endpoints when available.
-
+In the event of a failure, the gem will rotate through the specified
+endpoints so next one is tried on the next network call. The method call that
+trigger the error is not auto-retried, this responsibility lies with the calling
+application.
 
 ## Adding, Fetching and Deleting Keys
 ```ruby
@@ -106,6 +108,9 @@ Disabling auth will clear the auth token and all previously attached user inform
 ```
 conn.auth_disable
 ```
+
+When/if credentials expires, etcd3 call will raise `GRPC::Unauthenticated` and
+you will need to authenticate again.
 
 ## Leases
 ```ruby
@@ -210,8 +215,9 @@ Timeouts apply to and can be set when:
  - User, Role, and Authentication Management
  - Leases
  - Transactions
+ - Watch
 
-_Note: Timeouts currently do not affect Watch or Maintenance related commands._
+_Note: Timeouts currently do not affect Maintenance related commands._
 
 ## Contributing
 

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -21,14 +21,13 @@ class Etcdv3
   attr_reader :conn, :credentials, :options
   DEFAULT_TIMEOUT = 120
 
-  def initialize(allow_reconnect: true, **options)
+  def initialize(**options)
     @options = options
-    @options[:allow_reconnect] = allow_reconnect
     @timeout = options[:command_timeout] || DEFAULT_TIMEOUT
     @conn = ConnectionWrapper.new(
       @timeout,
       *sanitized_endpoints,
-      @options[:allow_reconnect],
+      @options.fetch(:allow_reconnect, true),
     )
     warn "WARNING: `url` is deprecated. Please use `endpoints` instead." if @options.key?(:url)
     authenticate(@options[:user], @options[:password]) if @options.key?(:user)

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -21,8 +21,9 @@ class Etcdv3
   attr_reader :conn, :credentials, :options
   DEFAULT_TIMEOUT = 120
 
-  def initialize(options = {})
+  def initialize(allow_reconnect: true, **options)
     @options = options
+    @options[:allow_reconnect] = allow_reconnect
     @timeout = options[:command_timeout] || DEFAULT_TIMEOUT
     @conn = ConnectionWrapper.new(
       @timeout,

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -24,7 +24,11 @@ class Etcdv3
   def initialize(options = {})
     @options = options
     @timeout = options[:command_timeout] || DEFAULT_TIMEOUT
-    @conn = ConnectionWrapper.new(@timeout, *sanitized_endpoints)
+    @conn = ConnectionWrapper.new(
+      @timeout,
+      *sanitized_endpoints,
+      allow_reconnect: @options[:allow_reconnect],
+    )
     warn "WARNING: `url` is deprecated. Please use `endpoints` instead." if @options.key?(:url)
     authenticate(@options[:user], @options[:password]) if @options.key?(:user)
   end

--- a/lib/etcdv3.rb
+++ b/lib/etcdv3.rb
@@ -28,7 +28,7 @@ class Etcdv3
     @conn = ConnectionWrapper.new(
       @timeout,
       *sanitized_endpoints,
-      allow_reconnect: @options[:allow_reconnect],
+      @options[:allow_reconnect],
     )
     warn "WARNING: `url` is deprecated. Please use `endpoints` instead." if @options.key?(:url)
     authenticate(@options[:user], @options[:password]) if @options.key?(:user)

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -3,7 +3,7 @@ class Etcdv3
 
     attr_accessor :connection, :endpoints, :user, :password, :token, :timeout
 
-    def initialize(timeout, *endpoints, allow_reconnect:)
+    def initialize(timeout, *endpoints, allow_reconnect)
       @user, @password, @token = nil, nil, nil
       @timeout = timeout
       @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout) }

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -3,7 +3,7 @@ class Etcdv3
 
     attr_accessor :connection, :endpoints, :user, :password, :token, :timeout
 
-    def initialize(timeout, *endpoints, allow_reconnect: true)
+    def initialize(timeout, *endpoints, allow_reconnect:)
       @user, @password, @token = nil, nil, nil
       @timeout = timeout
       @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout) }

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -10,16 +10,27 @@ class Etcdv3
       @connection = @endpoints.first
     end
 
-    def handle(stub, method, method_args=[])
+    def handle(stub, method, method_args=[], retries: 1)
       @connection.call(stub, method, method_args)
 
-    rescue GRPC::Unavailable, GRPC::Core::CallError
+    rescue GRPC::Unavailable, GRPC::Core::CallError => exception
       $stderr.puts("Failed to connect to endpoint '#{@connection.hostname}'")
       if @endpoints.size > 1
         rotate_connection_endpoint
         $stderr.puts("Failover event triggered. Failing over to '#{@connection.hostname}'")
+        return handle(stub, method, method_args)
+      else
+        return handle(stub, method, method_args)
       end
-      raise
+    rescue GRPC::Unauthenticated => exception
+      # Regenerate token in the event it expires.
+      if exception.details == 'etcdserver: invalid auth token'
+        if retries > 0
+          authenticate(@user, @password)
+          return handle(stub, method, method_args, retries: retries - 1)
+        end
+      end
+      raise exception
     end
 
     def clear_authentication

--- a/lib/etcdv3/connection_wrapper.rb
+++ b/lib/etcdv3/connection_wrapper.rb
@@ -3,31 +3,40 @@ class Etcdv3
 
     attr_accessor :connection, :endpoints, :user, :password, :token, :timeout
 
-    def initialize(timeout, *endpoints)
+    def initialize(timeout, *endpoints, allow_reconnect: true)
       @user, @password, @token = nil, nil, nil
       @timeout = timeout
       @endpoints = endpoints.map{|endpoint| Etcdv3::Connection.new(endpoint, @timeout) }
       @connection = @endpoints.first
+      @allow_reconnect = allow_reconnect
+    end
+
+    private def retry_or_raise(*args)
+      if @allow_reconnect
+        handle(*args)
+      else
+        raise
+      end
     end
 
     def handle(stub, method, method_args=[], retries: 1)
       @connection.call(stub, method, method_args)
 
-    rescue GRPC::Unavailable, GRPC::Core::CallError => exception
+    rescue GRPC::Unavailable, GRPC::Core::CallError
       $stderr.puts("Failed to connect to endpoint '#{@connection.hostname}'")
       if @endpoints.size > 1
         rotate_connection_endpoint
         $stderr.puts("Failover event triggered. Failing over to '#{@connection.hostname}'")
-        return handle(stub, method, method_args)
+        return retry_or_raise(stub, method, method_args)
       else
-        return handle(stub, method, method_args)
+        return retry_or_raise(stub, method, method_args)
       end
     rescue GRPC::Unauthenticated => exception
       # Regenerate token in the event it expires.
       if exception.details == 'etcdserver: invalid auth token'
         if retries > 0
           authenticate(@user, @password)
-          return handle(stub, method, method_args, retries: retries - 1)
+          return retry_or_raise(stub, method, method_args, retries: retries - 1)
         end
       end
       raise exception

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -47,6 +47,12 @@ describe Etcdv3::ConnectionWrapper do
         let(:allow_reconnect) { false }
         it { expect { subject }.to raise_error(GRPC::Unavailable) }
       end
+      context 'without reconnect with single endpoint' do
+        let(:modified_conn) {
+          local_connection("http://localhost:2369",allow_reconnect: false)
+        }
+        it { expect { subject }.to raise_error(GRPC::Unavailable) }
+      end
     end
     context 'with auth' do
       before do

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -33,7 +33,10 @@ describe Etcdv3::ConnectionWrapper do
     context 'without auth' do
       # Set primary endpoint to a non-existing etcd endpoint
       subject { modified_conn.get('boom') }
-      it { is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse) }
+      it do
+        expect { subject }.to raise_error(GRPC::Unavailable)
+        is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse)
+      end
     end
     context 'with auth' do
       before do
@@ -51,11 +54,14 @@ describe Etcdv3::ConnectionWrapper do
         modified_conn.user_delete('root')
       end
       subject { modified_conn.get('boom') }
-      it { is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse) }
+      it do
+        expect { subject }.to raise_error(GRPC::Unavailable)
+        is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse)
+      end
     end
   end
 
-  describe "GRPC::Unauthenticated recovery" do
+  describe "GRPC::Unauthenticated" do
     let(:wrapper) { conn.send(:conn) }
     let(:connection) { wrapper.connection }
     before do
@@ -71,6 +77,10 @@ describe Etcdv3::ConnectionWrapper do
       conn.user_delete('root')
     end
     subject { conn.user_get('root') }
-    it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGetResponse) }
+    it do
+      expect { subject }.to raise_error(GRPC::Unauthenticated)
+      conn.authenticate('root', 'pass')
+      is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGetResponse)
+    end
   end
 end

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -33,10 +33,7 @@ describe Etcdv3::ConnectionWrapper do
     context 'without auth' do
       # Set primary endpoint to a non-existing etcd endpoint
       subject { modified_conn.get('boom') }
-      it do
-        expect { subject }.to raise_error(GRPC::Unavailable)
-        is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse)
-      end
+      it { is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse) }
     end
     context 'with auth' do
       before do
@@ -54,14 +51,11 @@ describe Etcdv3::ConnectionWrapper do
         modified_conn.user_delete('root')
       end
       subject { modified_conn.get('boom') }
-      it do
-        expect { subject }.to raise_error(GRPC::Unavailable)
-        is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse)
-      end
+      it { is_expected.to be_an_instance_of(Etcdserverpb::RangeResponse) }
     end
   end
 
-  describe "GRPC::Unauthenticated" do
+  describe "GRPC::Unauthenticated recovery" do
     let(:wrapper) { conn.send(:conn) }
     let(:connection) { wrapper.connection }
     before do
@@ -77,10 +71,6 @@ describe Etcdv3::ConnectionWrapper do
       conn.user_delete('root')
     end
     subject { conn.user_get('root') }
-    it do
-      expect { subject }.to raise_error(GRPC::Unauthenticated)
-      conn.authenticate('root', 'pass')
-      is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGetResponse)
-    end
+    it { is_expected.to be_an_instance_of(Etcdserverpb::AuthUserGetResponse) }
   end
 end

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Etcdv3::ConnectionWrapper do
   let(:conn) { local_connection }
   let(:endpoints) { ['http://localhost:2379', 'http://localhost:2389'] }
+  subject { Etcdv3::ConnectionWrapper.new(10, *endpoints, allow_reconnect: true) }
 
   describe '#initialize' do
-    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
     it { is_expected.to have_attributes(user: nil, password: nil, token: nil) }
     it 'sets hostnames in correct order' do
       expect(subject.endpoints.map(&:hostname)).to eq(['localhost:2379', 'localhost:2389'])
@@ -16,7 +16,6 @@ describe Etcdv3::ConnectionWrapper do
   end
 
   describe "#rotate_connection_endpoint" do
-    subject { Etcdv3::ConnectionWrapper.new(10, *endpoints) }
     before do
       subject.rotate_connection_endpoint
     end

--- a/spec/etcdv3/connection_wrapper_spec.rb
+++ b/spec/etcdv3/connection_wrapper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Etcdv3::ConnectionWrapper do
   let(:conn) { local_connection }
   let(:endpoints) { ['http://localhost:2379', 'http://localhost:2389'] }
-  subject { Etcdv3::ConnectionWrapper.new(10, *endpoints, allow_reconnect: true) }
+  subject { Etcdv3::ConnectionWrapper.new(10, *endpoints, true) }
 
   describe '#initialize' do
     it { is_expected.to have_attributes(user: nil, password: nil, token: nil) }

--- a/spec/helpers/connections.rb
+++ b/spec/helpers/connections.rb
@@ -5,8 +5,8 @@ module Helpers
       Etcdv3.new(endpoints: "http://#{local_url}", user: user, password: password)
     end
 
-    def local_connection(endpoints="http://#{local_url}")
-      Etcdv3.new(endpoints: endpoints)
+    def local_connection(endpoints="http://#{local_url}", allow_reconnect: true)
+      Etcdv3.new(endpoints: endpoints, allow_reconnect: allow_reconnect)
     end
 
     def local_connection_with_timeout(timeout)


### PR DESCRIPTION
Currently this gems tries to do automatic retries to the next (or same)
endpoint in case of an error. This has two issues, stack overflow (retry
is by recursion) and not respecting timeouts. Stack overflow is
solvable, however the timeout issue not really given current
architecture.

Cleanest solution is to just rotate the endpoints and move the
responsibility for retry to the calling application.

Fixes davissp14/etcdv3-ruby#130
Fixes davissp14/etcdv3-ruby#131