### PR TITLE
Addressing zero-byte reference when using namespace

### DIFF
--- a/lib/etcdv3/namespace/kv/requests.rb
+++ b/lib/etcdv3/namespace/kv/requests.rb
@@ -17,16 +17,13 @@ class Etcdv3::Namespace::KV
 
     def get_request(key, opts)
       key = prepend_prefix(@namespace, key)
-     
       # In order to enforce the scope of the specified namespace, we are going to
       # intercept the zero-byte reference and re-target everything under the given namespace.
       if opts[:range_end] =~ /\x00/
         opts[:range_end] = (@namespace[0..-2] + (@namespace[-1].ord + 1).chr)
       else 
-        opts[:range_end] = prepend_prefix(@namespace, range_end) if range_end
+        opts[:range_end] = prepend_prefix(@namespace, opts[:range_end]) if opts[:range_end]
       end
-      opts[:range_end] = prepend_prefix(@namespace, opts[:range_end]) \
-        if opts[:range_end]
       opts[:sort_order] = SORT_ORDER[opts[:sort_order]] \
         if opts[:sort_order]
       opts[:sort_target] = SORT_TARGET[opts[:sort_target]] \

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -544,10 +544,25 @@ describe Etcdv3 do
 
       describe '#put' do
         before do
+
           ns_conn.put('apple_put', 'test')
         end
         it 'returns key with namespace' do 
           expect(conn.get("/namespace/apple_put").kvs.last.value).to eq('test')
+        end
+      end
+
+      describe '#del' do 
+        let(:del_conn) { local_connection_with_namespace("/del-test/") }
+        before do 
+          del_conn.put('test', "key")
+          del_conn.put('test2', "key2")
+          conn.put('wall', 'zzzz')
+        end
+
+        it 'deleting all keys should be scoped to namespace' do 
+          resp = del_conn.del('', range_end: "\0")
+          expect(resp.deleted).to eq(2)
         end
       end
 


### PR DESCRIPTION
Honor the namespace when using zero byte.  This will intercept any zero-byte references and rewrite them to target everything under the current namespace.. 


Addressing: https://github.com/davissp14/etcdv3-ruby/issues/136