### PR TITLE
Allow passing additional options directly to GRPC clients

### DIFF
--- a/lib/etcdv3/auth.rb
+++ b/lib/etcdv3/auth.rb
@@ -10,7 +10,7 @@ class Etcdv3
     }
 
     def initialize(hostname, credentials, timeout, metadata = {})
-      @stub = Etcdserverpb::Auth::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::Auth::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @metadata = metadata
     end

--- a/lib/etcdv3/kv.rb
+++ b/lib/etcdv3/kv.rb
@@ -5,7 +5,7 @@ class Etcdv3
     include GRPC::Core::TimeConsts
 
     def initialize(hostname, credentials, timeout, metadata={})
-      @stub = Etcdserverpb::KV::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::KV::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @metadata = metadata
     end

--- a/lib/etcdv3/lease.rb
+++ b/lib/etcdv3/lease.rb
@@ -3,7 +3,7 @@ class Etcdv3
     include GRPC::Core::TimeConsts
 
     def initialize(hostname, credentials, timeout, metadata={})
-      @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::Lease::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @metadata = metadata
     end

--- a/lib/etcdv3/lock.rb
+++ b/lib/etcdv3/lock.rb
@@ -3,7 +3,7 @@ class Etcdv3
     include GRPC::Core::TimeConsts
 
     def initialize(hostname, credentials, timeout, metadata = {})
-      @stub = V3lockpb::Lock::Stub.new(hostname, credentials)
+      @stub = V3lockpb::Lock::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @metadata = metadata
     end

--- a/lib/etcdv3/maintenance.rb
+++ b/lib/etcdv3/maintenance.rb
@@ -13,7 +13,7 @@ class Etcdv3
     }
 
     def initialize(hostname, credentials, _timeout, metadata = {})
-      @stub = Etcdserverpb::Maintenance::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::Maintenance::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @metadata = metadata
     end
 

--- a/lib/etcdv3/namespace/kv.rb
+++ b/lib/etcdv3/namespace/kv.rb
@@ -5,7 +5,7 @@ class Etcdv3::Namespace
     include GRPC::Core::TimeConsts
   
     def initialize(hostname, credentials, timeout, namespace, metadata={})
-      @stub = Etcdserverpb::KV::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::KV::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @namespace = namespace
       @metadata = metadata

--- a/lib/etcdv3/namespace/lock.rb
+++ b/lib/etcdv3/namespace/lock.rb
@@ -4,7 +4,7 @@ class Etcdv3::Namespace
     include Etcdv3::Namespace::Utilities
 
     def initialize(hostname, credentials, timeout, namespace, metadata = {})
-      @stub = V3lockpb::Lock::Stub.new(hostname, credentials)
+      @stub = V3lockpb::Lock::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @namespace = namespace
       @metadata = metadata

--- a/lib/etcdv3/namespace/watch.rb
+++ b/lib/etcdv3/namespace/watch.rb
@@ -4,7 +4,7 @@ class Etcdv3::Namespace
     include Etcdv3::Namespace::Utilities
 
     def initialize(hostname, credentials, timeout, namespace, metadata = {})
-      @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @namespace = namespace
       @metadata = metadata

--- a/lib/etcdv3/watch.rb
+++ b/lib/etcdv3/watch.rb
@@ -3,7 +3,7 @@ class Etcdv3
     include GRPC::Core::TimeConsts
 
     def initialize(hostname, credentials, timeout, metadata = {})
-      @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials)
+      @stub = Etcdserverpb::Watch::Stub.new(hostname, credentials, **metadata.delete(:client_options) || {})
       @timeout = timeout
       @metadata = metadata
     end


### PR DESCRIPTION
This can be useful, for example, to configure max message size, which is now possible via
```
Etcdv3::Connection.new('http://localhost:2379', 10, nil, :client_options => { :channel_args => { GRPC::Core::Channel::MAX_MESSAGE_LENGTH => 16*1024*1024 } })
```