### PR TITLE
fix: range_end is string

### DIFF
--- a/lib/etcdv3/namespace/kv/requests.rb
+++ b/lib/etcdv3/namespace/kv/requests.rb
@@ -32,14 +32,14 @@ class Etcdv3::Namespace::KV
       Etcdserverpb::RangeRequest.new(opts)
     end
 
-    def del_request(key, range_end=nil)
+    def del_request(key, range_end='')
       key = prepend_prefix(@namespace, key)
       # In order to enforce the scope of the specified namespace, we are going to
       # intercept the zero-byte reference and re-target everything under the given namespace.
       if range_end =~ /\x00/
         range_end = (@namespace[0..-2] + (@namespace[-1].ord + 1).chr)
       else 
-        range_end = prepend_prefix(@namespace, range_end) if range_end
+        range_end = prepend_prefix(@namespace, range_end) unless range_end.empty?
       end
       Etcdserverpb::DeleteRangeRequest.new(key: key, range_end: range_end)
     end

--- a/spec/etcdv3_spec.rb
+++ b/spec/etcdv3_spec.rb
@@ -578,8 +578,11 @@ describe Etcdv3 do
 
         context 'no range' do
           before { del_conn.put('test', 'value') }
-          subject { del_conn.del('test') }
-          it { is_expected.to_not be_nil }
+          it 'deleting key should be scoped to namespace' do
+            resp = del_conn.del('test')
+            expect(resp.deleted).to eq(1)
+            expect(del_conn.get('test').kvs).to be_empty
+          end
         end
 
         context 'ranged del' do
@@ -587,8 +590,11 @@ describe Etcdv3 do
             del_conn.put('test', 'value')
             del_conn.put('testt', 'value')
           end
-          subject { del_conn.del('test', range_end: 'testtt') }
-          it { is_expected.to_not be_nil }
+          it 'deleting keys should be scoped to namespace' do
+            resp = del_conn.del('test', range_end: 'testtt')
+            expect(resp.deleted).to eq(2)
+            expect(del_conn.get('test', range_end: 'testtt').kvs).to be_empty
+          end
         end
       end
 


### PR DESCRIPTION
The default value of range_end is defined as an empty string in Etcdv3::Namespace::KV.del.
However, nil is assumed in Etcdv3::Namespace::KV::Requests.del_request, creating an inconsistency.
Therefore, if range_end is not specified, namespace is assigned to range_end and del will not work correctly.